### PR TITLE
fix: update GitHub URLs to NIFU-NO org and add CRAN submission

### DIFF
--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,0 +1,3 @@
+Version: 0.8.8
+Date: 2026-03-13 14:20:30 UTC
+SHA: 68f1dd0e06f728cef18b1e9016023df0fa36b2f6

--- a/README.Rmd
+++ b/README.Rmd
@@ -18,9 +18,9 @@ knitr::opts_chunk$set(
 <!-- badges: start -->
 [![Lifecycle: stable](https://lifecycle.r-lib.org/articles/figures/lifecycle-stable.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 [![CRAN status](https://www.r-pkg.org/badges/version/readSX)](https://CRAN.R-project.org/package=readSX)
-[![R-CMD-check](https://github.com/sda030/readSX/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/sda030/readSX/actions/workflows/R-CMD-check.yaml)
-[![Codecov test coverage](https://codecov.io/gh/sda030/readSX/branch/main/graph/badge.svg)](https://app.codecov.io/gh/sda030/readSX?branch=main)
-[![Codecov test coverage](https://codecov.io/gh/sda030/readSX/graph/badge.svg)](https://app.codecov.io/gh/sda030/readSX)
+[![R-CMD-check](https://github.com/NIFU-NO/readSX/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/NIFU-NO/readSX/actions/workflows/R-CMD-check.yaml)
+[![Codecov test coverage](https://codecov.io/gh/NIFU-NO/readSX/branch/main/graph/badge.svg)](https://app.codecov.io/gh/NIFU-NO/readSX?branch=main)
+[![Codecov test coverage](https://codecov.io/gh/NIFU-NO/readSX/graph/badge.svg)](https://app.codecov.io/gh/NIFU-NO/readSX)
 <!-- badges: end -->
 
 The goal of readSX is to import survey data collected from the proprietary service SurveyXact. SurveyXact exports data in multiple tables: raw data, variable labels (and types), and value labels. 
@@ -36,7 +36,7 @@ You can install the development version of readSX like so:
 
 ``` r
 library(devtools)
-devtools::install_github("sda030/readSX")
+devtools::install_github("NIFU-NO/readSX")
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 stable](https://lifecycle.r-lib.org/articles/figures/lifecycle-stable.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/readSX)](https://CRAN.R-project.org/package=readSX)
-[![R-CMD-check](https://github.com/sda030/readSX/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/sda030/readSX/actions/workflows/R-CMD-check.yaml)
+[![R-CMD-check](https://github.com/NIFU-NO/readSX/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/NIFU-NO/readSX/actions/workflows/R-CMD-check.yaml)
 [![Codecov test
-coverage](https://codecov.io/gh/sda030/readSX/branch/main/graph/badge.svg)](https://app.codecov.io/gh/sda030/readSX?branch=main)
+coverage](https://codecov.io/gh/NIFU-NO/readSX/branch/main/graph/badge.svg)](https://app.codecov.io/gh/NIFU-NO/readSX?branch=main)
 [![Codecov test
-coverage](https://codecov.io/gh/sda030/readSX/graph/badge.svg)](https://app.codecov.io/gh/sda030/readSX)
+coverage](https://codecov.io/gh/NIFU-NO/readSX/graph/badge.svg)](https://app.codecov.io/gh/NIFU-NO/readSX)
 <!-- badges: end -->
 
 The goal of readSX is to import survey data collected from the


### PR DESCRIPTION
Minor fixes for CRAN:

- Update README badge URLs from `sda030/readSX` to `NIFU-NO/readSX`
- Update `install_github()` reference to `NIFU-NO/readSX`
- Add CRAN-SUBMISSION file for v0.8.8